### PR TITLE
Bug/fix htmltoxamlconverter

### DIFF
--- a/OctaneVSPlugin/Common/HTMLConverter/HtmlCssParser.cs
+++ b/OctaneVSPlugin/Common/HTMLConverter/HtmlCssParser.cs
@@ -280,7 +280,7 @@ namespace HTMLConverter
                 string number = styleValue.Substring(startIndex, nextIndex - startIndex);
 
                 string unit = ParseWordEnumeration(_fontSizeUnits, styleValue, ref nextIndex);
-                if (unit == null)
+                if (unit == null || unit == "em")
                 {
                     unit = "px"; // Assuming pixels by default
                 }

--- a/OctaneVSPlugin/Common/HTMLConverter/HtmlToXamlConverter.cs
+++ b/OctaneVSPlugin/Common/HTMLConverter/HtmlToXamlConverter.cs
@@ -2072,7 +2072,7 @@ namespace HTMLConverter
                         break;
 
                     case "text-indent":
-                        if (isBlock)
+                        if (isBlock && xamlElement.LocalName == HtmlToXamlConverter.Xaml_Paragraph)
                         {
                             xamlElement.SetAttribute(Xaml_TextIndent, (string)propertyEnumerator.Value);
                         }


### PR DESCRIPTION
Only enable TextIndent attribute on paragraphs
Treat "em" units as "px" when parsing CSS size in HtmlToXamlConverter