### PR TITLE
multiple line pasting in comments is now allowed

### DIFF
--- a/OctaneVSPlugin/View/DetailsToolWindowControl.xaml
+++ b/OctaneVSPlugin/View/DetailsToolWindowControl.xaml
@@ -621,6 +621,7 @@
                                           FontSize="12"
                                           MinWidth="250" MaxWidth="250"
                                           MinHeight="19" MaxHeight="19"
+                                          AcceptsReturn="True"
                                           Text="{Binding CommentText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                           Background="{DynamicResource VsBrush.Window}"
                                           Foreground="{DynamicResource VsBrush.WindowText}"

--- a/OctaneVSPlugin/ViewModel/DetailedItemViewModel.cs
+++ b/OctaneVSPlugin/ViewModel/DetailedItemViewModel.cs
@@ -26,6 +26,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web;
+using System.Windows;
 using System.Windows.Input;
 using Task = System.Threading.Tasks.Task;
 
@@ -500,6 +501,11 @@ namespace MicroFocus.Adm.Octane.VisualStudio.ViewModel
 
                 if (value != _commentText)
                 {
+                    if (value.Contains("\n"))
+                    {
+                        string valueTrimmed = value.Replace("\n", "<br>");
+                        value = valueTrimmed;
+                    }
                     _commentText = value;
                     NotifyPropertyChanged("CommentText");
                 }


### PR DESCRIPTION
Pasting multiple lines into the comment TextBox wasn't allowed because the textbox only allowed single lines pasting (no matter how long). Now it pastes all the lines and replaces "\n" with "<br>" so that lines are being kept while pasting. 