### PR TITLE
defect #1140094: Test connection now works as intented

### DIFF
--- a/OctaneVSPlugin/ConnectionSettings.cs
+++ b/OctaneVSPlugin/ConnectionSettings.cs
@@ -76,7 +76,6 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 			}
 			else
 			{
-				// save last succesful connection 
 				setOldCredentials();
 
 				// reset and thus require a new octane service obj
@@ -124,7 +123,6 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 				}
 				else
 				{
-					//get rid of the tested connection (that was not applied)
 					Run(async () => { return await OctaneServices.Reset(); }).Wait();
 
 					OctaneConfiguration.Username = oldUserPassConnectionInfo.user;
@@ -133,7 +131,6 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 					wsid = oldWsid;
 					OctaneServices.Create(oldUrl, oldSsid, oldWsid);
 
-					//connect to the old one 
 					Run(async () => { await OctaneServices.GetInstance().Connect(); }).Wait();
 
 					page.SetInfoLabelText("");

--- a/OctaneVSPlugin/ConnectionSettings.cs
+++ b/OctaneVSPlugin/ConnectionSettings.cs
@@ -48,14 +48,19 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 		private bool ssologin = false;
 		private ConnectionSettingsView page;
 
+		private UserPassConnectionInfo oldUserPassConnectionInfo;
+		private long oldSsid = 1001;
+		private long oldWsid = 1002;
+		private string oldUrl = "";
+
+
 		protected override void OnApply(PageApplyEventArgs e)
 		{
 
 			page.SetInfoLabelText("");
-			SaveSettingsToStorage();
 
-            // show welcome view if user clears the URL
-            if("".Equals(OctaneConfiguration.Url))
+			// show welcome view if user clears the URL
+			if ("".Equals(OctaneConfiguration.Url))
             {
 				if (OctaneMyItemsViewModel.Instance != null)
 				{
@@ -69,9 +74,11 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 			{
 				e.ApplyBehavior = ApplyKind.CancelNoNavigate;
 			}
-
 			else
 			{
+				// save last succesful connection 
+				setOldCredentials();
+
 				// reset and thus require a new octane service obj
 				Run(async () => { return await OctaneServices.Reset(); }).Wait();
 
@@ -96,14 +103,46 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 				{
 					InitialisePluginComponents();
 				}
-				
+
+				base.OnApply(e);
 			}
 
 			page.SetInfoLabelText(result);
-			base.OnApply(e);
 		}
 
-		private void openToolWindow()
+        protected override void OnClosed(EventArgs e)
+        {
+			
+			if (credentialLogin)
+            {
+				if ("".Equals(OctaneConfiguration.Url))
+				{
+					if (OctaneMyItemsViewModel.Instance != null)
+					{
+						OctaneMyItemsViewModel.Instance.Mode = MainWindowMode.FirstTime;
+					}
+				}
+				else
+				{
+					//get rid of the tested connection (that was not applied)
+					Run(async () => { return await OctaneServices.Reset(); }).Wait();
+
+					OctaneConfiguration.Username = oldUserPassConnectionInfo.user;
+					OctaneConfiguration.Password = oldUserPassConnectionInfo.password;
+					ssid = oldSsid;
+					wsid = oldWsid;
+					OctaneServices.Create(oldUrl, oldSsid, oldWsid);
+
+					//connect to the old one 
+					Run(async () => { await OctaneServices.GetInstance().Connect(); }).Wait();
+
+					page.SetInfoLabelText("");
+					base.OnClosed(e);
+				}
+			}
+		}
+
+        private void openToolWindow()
         {
 			IVsUIShell vsUIShell = (IVsUIShell)Package.GetGlobalService(typeof(SVsUIShell));
 			Guid guid = typeof(MainWindow).GUID;
@@ -141,27 +180,27 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 				
 				await authenticationStrategy.TestConnection(url);
 
-				// Don't do advanced test connection with sso login, will cause deadlock
-				if (credentialLogin)
-				{
-					// reset and thus require a new octane service obj
-					Run(async () => { return await OctaneServices.Reset(); }).Wait();
+                // Don't do advanced test connection with sso login, will cause deadlock
+                if (credentialLogin)
+                {
+                    // reset and thus require a new octane service obj
+                    Run(async () => { return await OctaneServices.Reset(); }).Wait();
 
-					// hotfix for first time installing the plugin and clicking test connection
-					if(OctaneConfiguration.CredentialLogin == false)
+                    // hotfix for first time installing the plugin and clicking test connection
+                    if (OctaneConfiguration.CredentialLogin == false)
                     {
-						OctaneConfiguration.CredentialLogin = true;
-					}
+                        OctaneConfiguration.CredentialLogin = true;
+                    }
 
-					// create a new service object
-					OctaneServices.Create(OctaneConfiguration.Url,
-							  OctaneConfiguration.SharedSpaceId,
-							  OctaneConfiguration.WorkSpaceId);
+                    // create a new service object
+                    OctaneServices.Create(OctaneConfiguration.Url,
+                              OctaneConfiguration.SharedSpaceId,
+                              OctaneConfiguration.WorkSpaceId);
 
-					await OctaneServices.GetInstance().Connect();
+                    await OctaneServices.GetInstance().Connect();
 
-					// try to get the work item root
-					await OctaneServices.GetInstance().GetAsyncWorkItemRoot();
+                    // try to get the work item root
+                    await OctaneServices.GetInstance().GetAsyncWorkItemRoot();
 				}
 
 				return ConnectionSuccessful;
@@ -333,6 +372,12 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 			}
 		}
 
-       
+		public void setOldCredentials()
+        {
+			oldUserPassConnectionInfo = new UserPassConnectionInfo(OctaneConfiguration.Username, OctaneConfiguration.Password);
+			oldSsid = OctaneConfiguration.SharedSpaceId;
+			oldWsid = OctaneConfiguration.WorkSpaceId;
+			oldUrl = OctaneConfiguration.Url;
+		}
 	}
 }

--- a/OctaneVSPlugin/MainWindowPackage.cs
+++ b/OctaneVSPlugin/MainWindowPackage.cs
@@ -88,7 +88,6 @@ namespace octane_visual_studio_plugin
             var optionsPage = (ConnectionSettings)GetDialogPage(typeof(ConnectionSettings));
             optionsPage.LoadSettingsFromStorage();
 
-            // Make sure that after restart/upgrade, we'll have old credentials setted
             optionsPage.setOldCredentials();
         }
 

--- a/OctaneVSPlugin/MainWindowPackage.cs
+++ b/OctaneVSPlugin/MainWindowPackage.cs
@@ -87,6 +87,9 @@ namespace octane_visual_studio_plugin
 
             var optionsPage = (ConnectionSettings)GetDialogPage(typeof(ConnectionSettings));
             optionsPage.LoadSettingsFromStorage();
+
+            // Make sure that after restart/upgrade, we'll have old credentials setted
+            optionsPage.setOldCredentials();
         }
 
         #endregion

--- a/OctaneVSPlugin/OctaneServices.cs
+++ b/OctaneVSPlugin/OctaneServices.cs
@@ -509,6 +509,16 @@ namespace MicroFocus.Adm.Octane.VisualStudio
         {
             return await es.GetOctaneVersion();
         }
+
+        public SharedSpaceContext GetSharedSpaceContext()
+        {
+            return sharedSpaceContext;
+        }
+
+        public WorkspaceContext GetWorkspaceContext()
+        {
+            return workspaceContext;
+        }
     }
 
 }

--- a/OctaneVSPlugin/View/ConnectionSettingsView.xaml.cs
+++ b/OctaneVSPlugin/View/ConnectionSettingsView.xaml.cs
@@ -72,6 +72,11 @@ namespace MicroFocus.Adm.Octane.VisualStudio.View
             }
         }
 
+        public string GetInfoLabelText()
+        {
+            return InfoLabel.Text;
+        }
+
         public void SetInfoLabelText(string text)
         {
             InfoLabel.Text = text;

--- a/OctaneVSPlugin/View/ConnectionSettingsView.xaml.cs
+++ b/OctaneVSPlugin/View/ConnectionSettingsView.xaml.cs
@@ -72,11 +72,6 @@ namespace MicroFocus.Adm.Octane.VisualStudio.View
             }
         }
 
-        public string GetInfoLabelText()
-        {
-            return InfoLabel.Text;
-        }
-
         public void SetInfoLabelText(string text)
         {
             InfoLabel.Text = text;


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1140094

**PROBLEM**
The connection settings were saved in the background after changing them, clicking Test connection and Cancel, but visually they remained _almost_ the same.

**SOLUTION**
Before this, the test connection button was like an _Apply_, even though Cancel was clicked afterwards. 
Made the test connection button to work as intended and if the Cancel button is clicked, the settings are not saved at all.
