### PR TITLE
defect #1154003: changed the logic of url parser so now supports webcontext

### DIFF
--- a/OctaneVSPlugin/Common/HTMLConverter/HtmlToXamlConverter.cs
+++ b/OctaneVSPlugin/Common/HTMLConverter/HtmlToXamlConverter.cs
@@ -725,8 +725,9 @@ namespace HTMLConverter
                 return;
             }
 
-            if (src.StartsWith("/api/shared_spaces"))
+            if (src.Contains("/api/shared_spaces"))
             {
+                src = src.Substring(src.IndexOf("/api/shared_spaces"));
                 // something went wrong with downloading the image from octane
                 // so show a hyperlink instead
                 XmlElement xamlElement = xamlParentElement.OwnerDocument.CreateElement(/*prefix:*/null, /*localName:*/HtmlToXamlConverter.Xaml_Hyperlink, _xamlNamespace);

--- a/OctaneVSPlugin/View/ConnectionSettingsView.xaml.cs
+++ b/OctaneVSPlugin/View/ConnectionSettingsView.xaml.cs
@@ -142,11 +142,11 @@ namespace MicroFocus.Adm.Octane.VisualStudio.View
                 string siteUrlLocalPath = siteUrl.LocalPath;
                 if (siteUrlLocalPath.EndsWith("/ui/")) 
                 {
-                    baseUrl += siteUrlLocalPath.Substring(1, siteUrlLocalPath.Length - 4);
+                    baseUrl += siteUrlLocalPath.Substring(1, siteUrlLocalPath.Length - 4); // remove the `/ui/` so we don't include it into baseUrl
                 }
                 else
                 {
-                    baseUrl += siteUrlLocalPath.Substring(1, siteUrlLocalPath.Length - 1);
+                    baseUrl += siteUrlLocalPath.Substring(1, siteUrlLocalPath.Length - 1); // remove the last `/`
                 }
                 
                 // trim the "/" from the end of the url

--- a/OctaneVSPlugin/View/ConnectionSettingsView.xaml.cs
+++ b/OctaneVSPlugin/View/ConnectionSettingsView.xaml.cs
@@ -139,6 +139,16 @@ namespace MicroFocus.Adm.Octane.VisualStudio.View
 
                 baseUrl = builder.Uri.ToString();
 
+                string siteUrlLocalPath = siteUrl.LocalPath;
+                if (siteUrlLocalPath.EndsWith("/ui/")) 
+                {
+                    baseUrl += siteUrlLocalPath.Substring(1, siteUrlLocalPath.Length - 4);
+                }
+                else
+                {
+                    baseUrl += siteUrlLocalPath.Substring(1, siteUrlLocalPath.Length - 1);
+                }
+                
                 // trim the "/" from the end of the url
                 baseUrl = baseUrl.TrimEnd('/');
 

--- a/OctaneVSPlugin/ViewModel/DetailedItemViewModel.cs
+++ b/OctaneVSPlugin/ViewModel/DetailedItemViewModel.cs
@@ -238,8 +238,10 @@ namespace MicroFocus.Adm.Octane.VisualStudio.ViewModel
                 {
                     var relativeUrl = image.Attr("src");
 
-                    if (relativeUrl == null || !relativeUrl.StartsWith("/api/shared_spaces"))
+                    if (relativeUrl == null || !relativeUrl.Contains("/api/shared_spaces"))
                         continue;
+
+                    relativeUrl = relativeUrl.Substring(relativeUrl.IndexOf("/api/shared_spaces"));
 
                     var imageName = relativeUrl.Split('/').LastOrDefault();
                     if (string.IsNullOrEmpty(imageName))


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1154003 

**PROBLEM**
If the url of the octane has anything else besides /ui/, like the /web-context/ui/, the parser didn't know how to handle it and threw errors.

**SOLUTION**
Made the parser know how to handle this new type of octane urls by adding the path to baseUrl. Also, had to edit the way images from description were downloaded.