### PR TITLE
defect #1163001: Add BDD to comment fields only if the version is greater than 15.1.4

### DIFF
--- a/OctaneVSPlugin/OctaneServices.cs
+++ b/OctaneVSPlugin/OctaneServices.cs
@@ -126,6 +126,18 @@ namespace MicroFocus.Adm.Octane.VisualStudio
                 await rest.ConnectAsync(url, authenticationStrategy);
                 user = await authenticationStrategy.GetWorkspaceUser();
             }
+
+            AddBddToCommentFieldsIfSupported();
+        }
+
+        private async void AddBddToCommentFieldsIfSupported()
+        {
+            // add bdd_spec field if the Octane version is greater than 15.1.4 (Coldplay P1)
+            OctaneVersion octaneVersion = await GetOctaneVersion();
+            if (octaneVersion.CompareTo(OctaneVersion.COLDPLAY_P1) > 0)
+            {
+                commentFields.Add(Comment.OWNER_BDD_SPEC_FIELD);
+            }
         }
 
 
@@ -262,7 +274,6 @@ namespace MicroFocus.Adm.Octane.VisualStudio
             Comment.OWNER_TEST_FIELD,
             Comment.OWNER_RUN_FIELD,
             Comment.OWNER_REQUIREMENT_FIELD,
-            Comment.OWNER_BDD_SPEC_FIELD,
             Comment.CREATION_TIME_FIELD,
             Comment.TEXT_FIELD
         };


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1163001

**PROBLEM**
The plugin throws error and does not work at all if the Octane version is lower than 15.1.4 ( version of Octane where BDD was implemented ), because of the BDD entity.

**SOLUTION**
Added the BDD to comment fields map only if the octane version is higher than 15.1.4, before using the map, so it won't send wrong request to server.