### PR TITLE
defect #1171009: Fix some login issues

### DIFF
--- a/OctaneVSPlugin/ConnectionSettings.cs
+++ b/OctaneVSPlugin/ConnectionSettings.cs
@@ -103,6 +103,11 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 					InitialisePluginComponents();
 				}
 
+				if (ssologin)
+				{
+					clearUserPassTextBoxes();
+				}
+
 				base.OnApply(e);
 			}
 
@@ -131,9 +136,19 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 					wsid = oldWsid;
 					OctaneServices.Create(oldUrl, oldSsid, oldWsid);
 
-					Run(async () => { await OctaneServices.GetInstance().Connect(); }).Wait();
-
-					page.SetInfoLabelText("");
+					try
+					{
+						Run(async () => { await OctaneServices.GetInstance().Connect(); }).Wait();
+					}
+					catch
+					{
+						clearUserPassTextBoxes();
+					}
+					finally
+					{
+						page.SetInfoLabelText("");
+					}
+					
 					base.OnClosed(e);
 				}
 			}
@@ -375,6 +390,12 @@ namespace MicroFocus.Adm.Octane.VisualStudio
 			oldSsid = OctaneConfiguration.SharedSpaceId;
 			oldWsid = OctaneConfiguration.WorkSpaceId;
 			oldUrl = OctaneConfiguration.Url;
+		}
+
+		private void clearUserPassTextBoxes()
+		{ 
+			page.usernameTextBox.Text = "";
+			page.passwordTextBox.Password = "";
 		}
 	}
 }

--- a/OctaneVSPlugin/OctaneServices.cs
+++ b/OctaneVSPlugin/OctaneServices.cs
@@ -133,11 +133,14 @@ namespace MicroFocus.Adm.Octane.VisualStudio
         private async void AddBddToCommentFieldsIfSupported()
         {
             // add bdd_spec field if the Octane version is greater than 15.1.4 (Coldplay P1)
-            OctaneVersion octaneVersion = await GetOctaneVersion();
-            if (octaneVersion.CompareTo(OctaneVersion.COLDPLAY_P1) > 0)
+            if (rest.IsConnected())
             {
-                commentFields.Add(Comment.OWNER_BDD_SPEC_FIELD);
-            }
+                OctaneVersion octaneVersion = await GetOctaneVersion();
+                if (octaneVersion.CompareTo(OctaneVersion.COLDPLAY_P1) > 0)
+                {
+                    commentFields.Add(Comment.OWNER_BDD_SPEC_FIELD);
+                }
+            } 
         }
 
 


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1171009

**PROBLEMS**
1. When switching from login with browser to user/pass credentials, if the password field was filled with old password, it would crash because of the encryption.
2. When closing login with browser pop-up, the IDE would crash.
3. When trying to cancel connection settings while having bad user/password, the IDE would crash.

**SOLUTIONS**
1. Clearing the user/pass textboxes when switching to login with browser.
2. The problem comes from the last commit where I verified the Octane server version. Added a verification before the GetOctaneVersion to see if the Rest Connector was successfully connected.
3. Surrounded an Octane connection block into a try catch, because if old user/pass were wrong, it would crash without showing any errors.