### PR TITLE
defect #1196020: added support for comments on task

### DIFF
--- a/OctaneVSPlugin/OctaneServices.cs
+++ b/OctaneVSPlugin/OctaneServices.cs
@@ -275,6 +275,7 @@ namespace MicroFocus.Adm.Octane.VisualStudio
             Comment.AUTHOR_FIELD,
             Comment.OWNER_WORK_FIELD,
             Comment.OWNER_TEST_FIELD,
+            Comment.OWNER_TASK,
             Comment.OWNER_RUN_FIELD,
             Comment.OWNER_REQUIREMENT_FIELD,
             Comment.CREATION_TIME_FIELD,
@@ -310,6 +311,7 @@ namespace MicroFocus.Adm.Octane.VisualStudio
         private readonly Dictionary<string, string> commentSupport = new Dictionary<string, string>
         {
             { "work_item", "owner_work_item" },
+            { "task", "owner_task" },
             { "test", "owner_test" },
             { "run", "owner_run" },
             { "requirement", "owner_requirement" }
@@ -368,15 +370,23 @@ namespace MicroFocus.Adm.Octane.VisualStudio
         /// </summary>
         public async Task<List<Comment>> GetAttachedCommentsToEntity(BaseEntity entity)
         {
-            if (string.IsNullOrEmpty(entity.AggregateType))
-                return new List<Comment>();
+            var ownerType = "";
+            if (entity.TypeName.Equals("task"))
+            {
+                ownerType = "owner_task";
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(entity.AggregateType))
+                    return new List<Comment>();
 
-            if (!commentSupport.TryGetValue(entity.AggregateType, out var type))
-                return new List<Comment>();
+                if (!commentSupport.TryGetValue(entity.AggregateType, out ownerType))
+                    return new List<Comment>();
+            }
 
             var query = new List<QueryPhrase>
             {
-                new CrossQueryPhrase(type, new LogicalQueryPhrase("id", entity.Id))
+                new CrossQueryPhrase(ownerType, new LogicalQueryPhrase("id", entity.Id))
             };
             var comments = await es.GetAsync<Comment>(workspaceContext, query, commentFields);
             return comments?.data;

--- a/OctaneVSPlugin/ViewModel/CommentViewModel.cs
+++ b/OctaneVSPlugin/ViewModel/CommentViewModel.cs
@@ -88,6 +88,9 @@ namespace MicroFocus.Adm.Octane.VisualStudio.ViewModel
             if (_commentEntity.OwnerRequirement != null)
                 return _commentEntity.OwnerRequirement;
 
+            if (_commentEntity.OwnerTask != null)
+                return _commentEntity.OwnerTask;
+
             return _commentEntity.OwnerBDDSpec;
         }
 

--- a/OctaneVSPlugin/ViewModel/DetailedItemViewModel.cs
+++ b/OctaneVSPlugin/ViewModel/DetailedItemViewModel.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Task = System.Threading.Tasks.Task;
+using TaskEntity = MicroFocus.Adm.Octane.Api.Core.Entities.Task;
 
 namespace MicroFocus.Adm.Octane.VisualStudio.ViewModel
 {
@@ -507,7 +508,10 @@ namespace MicroFocus.Adm.Octane.VisualStudio.ViewModel
             RunSuite.SUBTYPE_RUN_SUITE,
 
             // requirement
-            Requirement.SUBTYPE_DOCUMENT
+            Requirement.SUBTYPE_DOCUMENT,
+
+            // task
+            TaskEntity.TYPE_TASK
         };
 
         #region SaveEntity
@@ -661,36 +665,46 @@ namespace MicroFocus.Adm.Octane.VisualStudio.ViewModel
             string encodedCommment = "<html><body>" + CommentText + "</body></html>";
             commentToAdd.Text = encodedCommment;
 
-            string entityAggregateType = Entity.AggregateType;
-
-            switch (entityAggregateType)
+            if (Entity.TypeName == "task") // task does not have aggregate type
+            {              
+                TaskEntity commentOwnerTask = new TaskEntity();
+                commentOwnerTask.Id = Entity.Id;
+                commentOwnerTask.TypeName = Entity.TypeName;
+                commentToAdd.OwnerTask = commentOwnerTask;
+            }
+            else
             {
-                case "work_item":
-                    BaseEntity commentOwnerWorkItem = new BaseEntity();
-                    commentOwnerWorkItem.Id = Entity.Id;
-                    commentOwnerWorkItem.TypeName = Entity.TypeName;
-                    commentToAdd.OwnerWorkItem = commentOwnerWorkItem;
-                    break;
-                case "test":
-                    Test commentOwnerTest = new Test();
-                    commentOwnerTest.Id = Entity.Id;
-                    commentOwnerTest.TypeName = Entity.TypeName;
-                    commentToAdd.OwnerTest = commentOwnerTest;
-                    break;
-                case "requirement":
-                    Requirement commentOwnerRequirement = new Requirement();
-                    commentOwnerRequirement.Id = Entity.Id;
-                    commentOwnerRequirement.TypeName = Entity.TypeName;
-                    commentToAdd.OwnerRequirement = commentOwnerRequirement;
-                    break;
-                case "run":
-                    Run commentOwnerRun = new Run();
-                    commentOwnerRun.Id = Entity.Id;
-                    commentOwnerRun.TypeName = Entity.TypeName;
-                    commentToAdd.OwnerRun = commentOwnerRun;
-                    break;
-                default:
-                    break;
+                string entityAggregateType = Entity.AggregateType;
+
+                switch (entityAggregateType)
+                {
+                    case "work_item":
+                        BaseEntity commentOwnerWorkItem = new BaseEntity();
+                        commentOwnerWorkItem.Id = Entity.Id;
+                        commentOwnerWorkItem.TypeName = Entity.TypeName;
+                        commentToAdd.OwnerWorkItem = commentOwnerWorkItem;
+                        break;
+                    case "test":
+                        Test commentOwnerTest = new Test();
+                        commentOwnerTest.Id = Entity.Id;
+                        commentOwnerTest.TypeName = Entity.TypeName;
+                        commentToAdd.OwnerTest = commentOwnerTest;
+                        break;
+                    case "requirement":
+                        Requirement commentOwnerRequirement = new Requirement();
+                        commentOwnerRequirement.Id = Entity.Id;
+                        commentOwnerRequirement.TypeName = Entity.TypeName;
+                        commentToAdd.OwnerRequirement = commentOwnerRequirement;
+                        break;
+                    case "run":
+                        Run commentOwnerRun = new Run();
+                        commentOwnerRun.Id = Entity.Id;
+                        commentOwnerRun.TypeName = Entity.TypeName;
+                        commentToAdd.OwnerRun = commentOwnerRun;
+                        break;
+                    default:
+                        break;
+                }
             }
             CommentText = "";
 


### PR DESCRIPTION
https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=1196020

**Problem**
'Show comments for current entity' button is missing for Task entity

**Solution**
Added support for task entity - special case because Task does not have aggregate type. Also, added support for comment entity on task parent.