### PR TITLE
defect #1514108: add shortcut for opening task parent

### DIFF
--- a/OctaneVSPlugin/View/ToolWindowHelper.cs
+++ b/OctaneVSPlugin/View/ToolWindowHelper.cs
@@ -33,10 +33,10 @@ namespace MicroFocus.Adm.Octane.VisualStudio.View
     {
         internal const string AppName = "ALM Octane";
         internal const string ViewDetailsHeader = "View details (DblClick)";
-        internal const string ViewTaskParentDetailsHeader = "View parent details (DblClick)";
+        internal const string ViewTaskParentDetailsHeader = "View parent details (Ctrl + DblClick)";
         internal const string ViewCommentParentDetailsHeader = "View parent details (DblClick)";
         internal const string OpenInBrowserHeader = "Open in Browser (Alt + DblClick)";
-        internal const string CopyCommitMessageHeader = "Copy Commit Message to Clipboard (Shift+Alt+DblClick)";
+        internal const string CopyCommitMessageHeader = "Copy Commit Message to Clipboard (Shift + Alt + DblClick)";
         internal const string DownloadScriptHeader = "Download Script";
         internal const string StartWorkHeader = "Start Work";
         internal const string StopWorkHeader = "Stop Work";
@@ -64,6 +64,10 @@ namespace MicroFocus.Adm.Octane.VisualStudio.View
                     {
                         OpenInBrowser(entity);
                     }
+                }
+                else if (entity.TypeName.Equals(Task.TYPE_TASK) && (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)))
+                {
+                    ViewDetails(((Task) entity).Story);
                 }
                 else
                 {


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1514108

**Problem**: View parent details had the same shortcut with View details for Task entity.

**Solution**: Added Ctrl + Double click for opening task parent entity 