### PR TITLE
defect #2411004: added full commit message when copying to clipboard

### DIFF
--- a/OctaneVSPlugin/ViewModel/OctaneItemViewModel.cs
+++ b/OctaneVSPlugin/ViewModel/OctaneItemViewModel.cs
@@ -128,16 +128,18 @@ namespace MicroFocus.Adm.Octane.VisualStudio.ViewModel
                 if (!IsSupportCopyCommitMessage)
                     return string.Empty;
 
+                string commitMessage = "my commit message";
+
                 if (Entity.TypeName == Task.TYPE_TASK)
                 {
                     var parentEntity = Utility.GetTaskParentEntity(Entity);
                     var parentEntityTypeInfo = EntityTypeRegistry.GetEntityTypeInformation(parentEntity);
 
-                    return $"{parentEntityTypeInfo.CommitMessage} #{parentEntity.Id}: {EntityTypeInformation.CommitMessage} #{ID}: ";
+                    return $"{parentEntityTypeInfo.CommitMessage} #{parentEntity.Id}: {EntityTypeInformation.CommitMessage} #{ID}: {commitMessage}";
                 }
                 else
                 {
-                    return $"{EntityTypeInformation.CommitMessage} #{ID}: ";
+                    return $"{EntityTypeInformation.CommitMessage} #{ID}: {commitMessage}";
                 }
             }
         }


### PR DESCRIPTION
[https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2411004](https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2411004)

**Problem:** When user tries to copy commit message to clipboard it will be only copied as "defect #1234", instead of "defect #1234: my commit message".

**Solution:** I added full commit message text ("defect #1234: my commit message") when user copies message to clipboard.